### PR TITLE
Add counter javascript to each page on the site

### DIFF
--- a/site-config.yml
+++ b/site-config.yml
@@ -1,3 +1,23 @@
 ---
 hub: "cdcepi/FluSight-forecast-hub/"
 title: "FluSight Forecast Hub Dashboard"
+html:
+  include-after-body:
+    - text: |
+        <!-- Default Statcounter code for CDC FluSight Hub Dashboard https://reichlab.io/flusight-dashboard/ -->
+        <script type="text/javascript">
+        var sc_project=13093554;
+        var sc_invisible=1;
+        var sc_security="e010bf14";
+        </script>
+        <script type="text/javascript"
+        src="https://www.statcounter.com/counter/counter.js"
+        async></script>
+        <noscript><div class="statcounter"><a title="Web Analytics"
+        href="https://statcounter.com/" target="_blank"><img
+        class="statcounter"
+        src="https://c.statcounter.com/13093554/0/e010bf14/1/"
+        alt="Web Analytics"
+        referrerPolicy="no-referrer-when-downgrade"></a></div></noscript>
+        <!-- End of Statcounter Code -->
+        </script>


### PR DESCRIPTION
Closes #10 

Since the dashboard builder will merge site-config.yml with the default quarto config file, we can use quarto's `include-after-body` directive to inject a javascript snippet on each each page.
https://quarto.org/docs/output-formats/html-basics.html#includes

Updated to add: here's what the staging dashboard looks like after this change: https://reichlab.io/flusight-dashboard-staging/