### PR TITLE
Add ed visits evaluations

### DIFF
--- a/predevals-config.yml
+++ b/predevals-config.yml
@@ -16,6 +16,21 @@ targets:
   - reference_date
   - horizon
   - target_end_date
+- target_id: wk inc flu prop ed visits
+  metrics:
+  - wis
+  - ae_median
+  - interval_coverage_50
+  - interval_coverage_95
+  relative_metrics:
+  - wis
+  - ae_median
+  baseline: FluSight-baseline
+  disaggregate_by:
+  - location
+  - reference_date
+  - horizon
+  - target_end_date
 eval_sets:
 - eval_set_name: 2025-2026 season, state level
   task_filters:


### PR DESCRIPTION
As the title says

Note that the ED visits target has the option to select evaluation sets for seasons before it was implemented, which stays on the last valid evaluation table that the user viewed on the website. This is documented in https://github.com/hubverse-org/predevals/issues/31, and is one of the polish issues for the Expand Hubverse Eval Metrics and Dashboard Support project

**Edit: We are waiting until that issue is fixed to merge in this PR, as the above mentioned behavior is not desirable**